### PR TITLE
Fix NullreferenceException when using IWearableShapeSupplier

### DIFF
--- a/Common/Entity/EntityAgent.cs
+++ b/Common/Entity/EntityAgent.cs
@@ -860,7 +860,7 @@ namespace Vintagestory.API.Common
             entityShape.StepParentShape(
                 gearShape, 
                 texturePrefixCode, 
-                compGearShape.Base.ToString() + string.Format("defined in {0} {1}", stack.Class, stack.Collectible.Code),
+                compGearShape?.Base.ToString() ?? "Custom texture from ItemWearableShapeSupplier " + string.Format("defined in {0} {1}", stack.Class, stack.Collectible.Code),
                 shapePathForLogging, 
                 Api.World.Logger,
                 (texcode, tloc) =>


### PR DESCRIPTION
The new Update of the gear rendering causes Nullreferences whenever using the IWearableShapeSupplier. I tested with the vanilla glider as well as with modded dog collars.

The exception showing is the following:
```
System.NullReferenceException: Object reference not set to an instance of an object.
   at Vintagestory.API.Common.EntityAgent.addGearToShape(ItemSlot slot, Shape entityShape, String shapePathForLogging) in VintagestoryApi\Common\Entity\EntityAgent.cs:line 860
   at Vintagestory.API.Common.EntityPlayer.OnTesselation(Shape& entityShape, String shapePathForLogging) in VintagestoryApi\Common\Entity\EntityPlayer.cs:line 386
   at Vintagestory.GameContent.EntityShapeRenderer.TesselateShape(Action`1 onMeshDataReady, String[] overrideSelectiveElements) in VSEssentials\EntityRenderer\EntityShapeRenderer.cs:line 246
   at Vintagestory.GameContent.EntityPlayerShapeRenderer.Tesselate() in VSEssentials\EntityRenderer\EntityPlayerShapeRenderer.cs:line 61
   at Vintagestory.GameContent.EntityPlayerShapeRenderer.TesselateShape() in VSEssentials\EntityRenderer\EntityPlayerShapeRenderer.cs:line 30
   at Vintagestory.GameContent.EntityShapeRenderer.BeforeRender(Single dt) in VSEssentials\EntityRenderer\EntityShapeRenderer.cs:line 429
   at Vintagestory.Client.NoObf.SystemRenderEntities.OnBeforeRender(Single dt) in VintagestoryLib\Client\Systems\Render\RenderEntities.cs:line 49
   at Vintagestory.Client.NoObf.ClientEventManager.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\Util\ClientEventManager.cs:line 185
   at Vintagestory.Client.NoObf.ClientMain.TriggerRenderStage(EnumRenderStage stage, Single dt) in VintagestoryLib\Client\ClientMain.cs:line 796
   at Vintagestory.Client.NoObf.ClientMain.MainRenderLoop(Single dt) in VintagestoryLib\Client\ClientMain.cs:line 802
   at Vintagestory.Client.NoObf.ClientMain.MainGameLoop(Single deltaTime) in VintagestoryLib\Client\ClientMain.cs:line 718
   at Vintagestory.Client.GuiScreenRunningGame.RenderToPrimary(Single dt) in VintagestoryLib\Client\MainMenu\Screens\GuiScreenRunningGame.cs:line 200
   at Vintagestory.Client.ScreenManager.Render(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 668
   at Vintagestory.Client.ScreenManager.OnNewFrame(Single dt) in VintagestoryLib\Client\ScreenManager.cs:line 643
   at Vintagestory.Client.NoObf.ClientPlatformWindows.window_RenderFrame(FrameEventArgs e) in VintagestoryLib\Client\ClientPlatform\GameWindow.cs:line 78
   at OpenTK.Windowing.Desktop.GameWindow.Run()
   at Vintagestory.Client.ClientProgram.Start(ClientProgramArgs args, String[] rawArgs) in VintagestoryLib\Client\ClientProgram.cs:line 322
   at Vintagestory.Client.ClientProgram.<>c__DisplayClass9_0.<.ctor>b__1() in VintagestoryLib\Client\ClientProgram.cs:line 128
   at Vintagestory.ClientNative.CrashReporter.Start(ThreadStart start) in VintagestoryLib\Client\ClientPlatform\ClientNative\CrashReporter.cs:line 93
```