### PR TITLE
Implement OverlayCutout blend mode

### DIFF
--- a/Math/ColorBlend.cs
+++ b/Math/ColorBlend.cs
@@ -990,12 +990,11 @@ namespace Vintagestory.API.MathTools
         {
             VSColor lhs = new(rgb1);
             VSColor rhs = new(rgb2);
-        
-            if (lhs.A > 0 && rhs.A > 0)
+            if (rhs.A != 0)
             {
-                return 0;
+                lhs.A = 0;
             }
-            return ColorBlend.Overlay(rgb1, rgb2);
+            return lhs.AsInt;
         }
 
 

--- a/Math/ColorBlend.cs
+++ b/Math/ColorBlend.cs
@@ -61,7 +61,8 @@ namespace Vintagestory.API.MathTools
         Screen = 4,
         ColorDodge = 5,
         ColorBurn = 6,
-        Overlay = 7
+        Overlay = 7,
+        OverlayCutout = 8
     }
 
 
@@ -81,7 +82,8 @@ namespace Vintagestory.API.MathTools
                 Screen,
                 ColorDodge,
                 ColorBurn,
-                Overlay
+                Overlay,
+                OverlayCutout
             };
         }
 
@@ -984,6 +986,17 @@ namespace Vintagestory.API.MathTools
             return (int)ret;
         }
 
+        public static int OverlayCutout(int rgb1, int rgb2)
+        {
+            VSColor lhs = new(rgb1);
+            VSColor rhs = new(rgb2);
+        
+            if (lhs.A > 0 && rhs.A > 0)
+            {
+                return 0;
+            }
+            return ColorBlend.Overlay(rgb1, rgb2);
+        }
 
 
 


### PR DESCRIPTION
Replace original pixel with alpha if overlay is not alpha pixel.

Very useful for content mods, for example, cutouts for banners.
![image](https://github.com/anegostudios/vsapi/assets/69315569/2320167c-d44a-419b-8e5d-4f6c51cc2219)

Bottom texture:
![image](https://github.com/anegostudios/vsapi/assets/69315569/d14e8d0e-39d4-42e1-80a2-4cc7675f6f1a)

Top texture:
![image](https://github.com/anegostudios/vsapi/assets/69315569/4a204751-1697-4386-a26e-0ad1712a0720)

Output:
![image](https://github.com/anegostudios/vsapi/assets/69315569/8c56f7a0-942c-4104-80e5-6e9a1a48002e)
