### PR TITLE
Round health to two decimal places in collectible tooltip

### DIFF
--- a/Common/Collectible/Collectible.cs
+++ b/Common/Collectible/Collectible.cs
@@ -1655,7 +1655,7 @@ namespace Vintagestory.API.Common
 
                 if (Math.Abs(nutriProps.Health * healthLossMul) > 0.001f)
                 {
-                    dsc.AppendLine(Lang.Get("When eaten: {0} sat, {1} hp", Math.Round(nutriProps.Satiety * satLossMul), nutriProps.Health * healthLossMul));
+                    dsc.AppendLine(Lang.Get("When eaten: {0} sat, {1} hp", Math.Round(nutriProps.Satiety * satLossMul), Math.Round(nutriProps.Health * healthLossMul, 2)));
                 }
                 else
                 {


### PR DESCRIPTION
Health is not currently rounded in collectible tooltips, by rounding it to 2 decimal places (or 1, if you think that is better) would allow to display the health gain with some precision, but avoid the ugly decimal string that comes when the health is multiplied by the spoilage factor as food spoils.