### PR TITLE
Correct typo in method name

### DIFF
--- a/Common/Collectible/Block/Block.cs
+++ b/Common/Collectible/Block/Block.cs
@@ -2282,6 +2282,12 @@ namespace Vintagestory.API.Common
         /// <param name="world"></param>
         /// <param name="pos"></param>
         /// <returns></returns>
+        public virtual bool DoPartialSelection(IWorldAccessor world, BlockPos pos)
+        {
+            return PartialSelection;
+        }
+
+        [Obsolete("Use DoPartialSelection() instead")]
         public virtual bool DoParticalSelection(IWorldAccessor world, BlockPos pos)
         {
             return PartialSelection;


### PR DESCRIPTION
The method DoPartialSelection was wrongly named DoParticalSelection, obsoleting the wrong naming and introducing a new method with the correct one instead