### PR TITLE
Allow Block Behaviors to Add Functionality OnEntityInside and OnEntityCollide

### DIFF
--- a/Common/Collectible/Block/Block.cs
+++ b/Common/Collectible/Block/Block.cs
@@ -1517,7 +1517,17 @@ namespace Vintagestory.API.Common
         /// <param name="pos"></param>
         public virtual void OnEntityInside(IWorldAccessor world, Entity entity, BlockPos pos)
         {
+            bool preventDefault = false;
+            foreach (BlockBehavior behavior in BlockBehaviors)
+            {
+                EnumHandling handled = EnumHandling.PassThrough;
 
+                behavior.OnEntityInside(world, entity, pos);
+                if (handled == EnumHandling.PreventDefault) preventDefault = true;
+                if (handled == EnumHandling.PreventSubsequent) return;
+            }
+
+            if (preventDefault) return;
         }
 
 
@@ -1533,6 +1543,18 @@ namespace Vintagestory.API.Common
         /// <param name="isImpact"></param>
         public virtual void OnEntityCollide(IWorldAccessor world, Entity entity, BlockPos pos, BlockFacing facing, Vec3d collideSpeed, bool isImpact)
         {
+            bool preventDefault = false;
+            foreach (BlockBehavior behavior in BlockBehaviors)
+            {
+                EnumHandling handled = EnumHandling.PassThrough;
+
+                behavior.OnEntityCollide(world, entity, pos, facing, collideSpeed, isImpact)
+                if (handled == EnumHandling.PreventDefault) preventDefault = true;
+                if (handled == EnumHandling.PreventSubsequent) return;
+            }
+
+            if (preventDefault) return;
+
             if (entity.Properties.CanClimb == true && (IsClimbable(pos) || entity.Properties.CanClimbAnywhere) && facing.IsHorizontal && entity is EntityAgent)
             {
                 EntityAgent ea = entity as EntityAgent;

--- a/Common/Collectible/Block/BlockBehavior.cs
+++ b/Common/Collectible/Block/BlockBehavior.cs
@@ -264,6 +264,32 @@ namespace Vintagestory.API.Common
             return false;
         }
 
+        /// <summary>
+        /// When an entity is inside a block 1x1x1 space, independent of of its selection box or collision box
+        /// </summary>
+        /// <param name="world"></param>
+        /// <param name="entity"></param>
+        /// <param name="pos"></param>
+        public virtual void OnEntityInside(IWorldAccessor world, Entity entity, BlockPos pos)
+        {
+            handling = EnumHandling.PassThrough;
+            return false;
+        }
+
+        /// <summary>
+        /// Whenever an entity collides with the collision box of the block
+        /// </summary>
+        /// <param name="world"></param>
+        /// <param name="entity"></param>
+        /// <param name="pos"></param>
+        /// <param name="facing"></param>
+        /// <param name="collideSpeed"></param>
+        /// <param name="isImpact"></param>
+        public virtual void OnEntityCollide(IWorldAccessor world, Entity entity, BlockPos pos, BlockFacing facing, Vec3d collideSpeed, bool isImpact)
+        {
+            handling = EnumHandling.PassThrough;
+            return false;
+        }
 
         /// <summary>
         /// Step 1: Called when the player attempts to place this block. The default behavior calls Block.DoPlaceBlock().


### PR DESCRIPTION
I found [this file](https://github.com/anegostudios/vssurvivalmod/blob/8d875722b93c39a353846e25aeb83bc1b50d32bb/Block/BlockDamageOnTouch.cs) which just adds some logic that makes a block apply damage when something touches it, and I saw that it also has a “plant” version of the class that checks for some conditions during world gen.

I realized that these things would probably make more sense as a behavior, like “BlockBehaviorDamageOnTouch” or something, but that’s not currently possible with the API, so I am submitting this change so that this could be added as a behavior and therefore allow for any type of block to have something like this, such as the cactus, instead of needing to program it on a per block basis.