### PR TITLE
Fix BlendedOverlays trying to resolve in wrong domain (when base texture is from different domain)

### DIFF
--- a/Client/Texture/CompositeTexture.cs
+++ b/Client/Texture/CompositeTexture.cs
@@ -413,7 +413,7 @@ namespace Vintagestory.API.Client
                 {
                     BlendedOverlayTexture bov = ct.BlendedOverlays[i];
                     bct.TextureFilenames[i + 1] = bov.Base;
-                    bct.BakedName.Path += OverlaysSeparator + ((int)bov.BlendMode).ToString() + BlendmodeSeparator + bov.Base.ToShortString();
+                    bct.BakedName.Path += OverlaysSeparator + ((int)bov.BlendMode).ToString() + BlendmodeSeparator + (ct.Base.Domain == bov.Base.Domain ? bov.Base.ToShortString() : bov.Base.ToString());
                 }
             }
             else


### PR DESCRIPTION
Only use ToShortString if both domains are the same
(This prevents it from trying to use a wrong default domain later on)