### PR TITLE
Add BlockBehaviors to CollectibleBehaviors

### DIFF
--- a/Common/Collectible/Block/Block.cs
+++ b/Common/Collectible/Block/Block.cs
@@ -62,6 +62,14 @@ namespace Vintagestory.API.Common
         public virtual string RemapToLiquidsLayer { get { return null; } }
 
         /// <summary>
+        /// Modifiers that can alter the behavior of a block, particularly when being placed or removed
+        /// </summary>
+        public BlockBehavior[] BlockBehaviors { get; } = new BlockBehavior[0];
+
+        public override CollectibleBehavior[] CollectibleBehaviors =>
+            base.CollectibleBehaviors.Concat(BlockBehaviors.Cast<CollectibleBehavior>()).ToArray();
+
+        /// <summary>
         /// Unique number of the block. Same as <see cref="Id"/>. This number depends on the order in which the blocks are order. The numbering is however always ensured to remain the same on a per world basis.
         /// </summary>
         public int BlockId;
@@ -322,11 +330,6 @@ namespace Vintagestory.API.Common
         /// </summary>
         public bool HasAlternates;
         public bool HasTiles;
-
-        /// <summary>
-        /// Modifiers that can alter the behavior of a block, particularly when being placed or removed
-        /// </summary>
-        public BlockBehavior[] BlockBehaviors = new BlockBehavior[0];
 
         /// <summary>
         /// Modifiers that can alter the behavior of a block entity
@@ -2011,7 +2014,7 @@ namespace Vintagestory.API.Common
             return Climbable;
         }
 
-        
+
 
         /// <summary>
         /// The cost of traversing this block as part of the AI pathfinding system.

--- a/Common/Collectible/Collectible.cs
+++ b/Common/Collectible/Collectible.cs
@@ -21,14 +21,6 @@ namespace Vintagestory.API.Common
     /// </summary>
     public abstract class CollectibleObject : RegistryObject
     {
-        // ---- Some default objects which are common to many Block and Item objects
-        public readonly static Size3f DefaultSize = new Size3f(0.5f, 0.5f, 0.5f);
-
-        /// <summary>
-        /// Liquids are handled and rendered differently than solid blocks.
-        /// </summary>
-        public EnumMatterState MatterState = EnumMatterState.Solid;
-
         /// <summary>
         /// This value is set the the BlockId or ItemId-Remapper if it encounters a block/item in the savegame,
         /// but no longer exists as a loaded block/item
@@ -49,10 +41,23 @@ namespace Vintagestory.API.Common
         }
 
         /// <summary>
+        /// Modifiers that can alter the behavior of the item or block, mostly for held interaction
+        /// Child classes can override this to add their own behaviors provided they inherit from CollectibleBehavior
+        /// </summary>
+        public virtual CollectibleBehavior[] CollectibleBehaviors { get; } = new CollectibleBehavior[0];
+
+        /// <summary>
         /// Block or Item?
         /// </summary>
         public abstract EnumItemClass ItemClass { get; }
 
+        // ---- Some default objects which are common to many Block and Item objects
+        public readonly static Size3f DefaultSize = new Size3f(0.5f, 0.5f, 0.5f);
+
+        /// <summary>
+        /// Liquids are handled and rendered differently than solid blocks.
+        /// </summary>
+        public EnumMatterState MatterState = EnumMatterState.Solid;
 
         /// <summary>
         /// Max amount of collectible that one default inventory slot can hold
@@ -245,18 +250,10 @@ namespace Vintagestory.API.Common
         /// </summary>
         protected ICoreAPI api;
 
-
-        /// <summary>
-        /// Modifiers that can alter the behavior of the item or block, mostly for held interaction
-        /// </summary>
-        public CollectibleBehavior[] CollectibleBehaviors = new CollectibleBehavior[0];
-
         /// <summary>
         /// For light emitting collectibles: hue, saturation and brightness value
         /// </summary>
         public byte[] LightHsv = new byte[3];
-
-
 
         // Non overridable so people don't accidently forget to call the base method for assigning the api in OnLoaded
         public void OnLoadedNative(ICoreAPI api)


### PR DESCRIPTION
Currently, `BlockBehaviors` from the `Block` class aren't included in `CollectibleBehaviors`, even though `BlockBehavior` inherits from `CollectibleBehavior`.  This prevents methods like `OnLoaded` (which can be overridden in `BlockBehavior`) from being called, as `CollectibleObject` only invokes this method from its `CollectibleBehaviors` field. This PR addresses this by making `CollectibleBehaviors` a virtual property overridden by the `Block` class, ensuring that `BlockBehaviors` are properly included and their methods are called.
