### PR TITLE
Self-documenting code: This value is only true for runtime spawns and creature item usage, not worldgen spawns

### DIFF
--- a/Common/Entity/EntityBehavior.cs
+++ b/Common/Entity/EntityBehavior.cs
@@ -36,7 +36,7 @@ namespace Vintagestory.API.Common.Entities
         /// <summary>
         /// Called after initializing all the behaviors in case they need to cross-refer to each other or set some initial values only at spawn-time
         /// </summary>
-        public virtual void AfterInitialized(bool onFirstSpawn)
+        public virtual void AfterInitialized(bool onRuntimeSpawn)
         {
         }
 


### PR DESCRIPTION
AfterInitialized(onFirstSpawn) is called with 'true' for runtime spawns and 'false' for worldgen spawns, rather than the 'true' for all spawns and 'false' for loaded from saved chunks that I would expect from the parameter name. The current behavior could be either intentional or a bug.

On the one hand, a distinction between new vs loaded entities is more broadly useful than a distinction between new runtime spawns vs loaded or worldgen spawned entities, as this determines whether values should be kept or generated. 

On the other hand, you can decide whether to generate values based on whether a value is present in the attributes tree (though you get into a much trickier situation if adding new functionality that loaded entities also don't have), but if you wanted to do something different between runtime and worldgen spawned entities, that would be nearly impossible without this.

On the third hand, testing shows that it has been this way since the AfterInitialized function was added in 1.18. If this is an API bug, it's an API bug that has existed for as long as the relevant portion of the API has. In light of that, I am inclined to assume that it is intentional and should be documented, rather than unintentional and should be fixed.

But please, do either document this or fix it. <3