### PR TITLE
Fix null object reference in Block.GetDrops

### DIFF
--- a/Common/Collectible/Block/Block.cs
+++ b/Common/Collectible/Block/Block.cs
@@ -1249,7 +1249,7 @@ namespace Vintagestory.API.Common
                 if (dstack.Tool != null && (byPlayer == null || dstack.Tool != byPlayer.InventoryManager.ActiveTool)) continue;
 
                 float extraMul = 1f;
-                if (dstack.DropModbyStat != null)
+                if (byPlayer != null && dstack.DropModbyStat != null)
                 {
                     // If the stat does not exist, then GetBlended returns 1 \o/
                     extraMul = byPlayer.Entity.Stats.GetBlended(dstack.DropModbyStat);


### PR DESCRIPTION
This fixes a null object reference that can happen when Block.GetDrops is called with byPlayer=null and it has drops modified by a player stat.

fixes https://github.com/anegostudios/VintageStory-Issues/issues/5959