### PR TITLE
Use GridRecipe in CollectibleBehavior.OnCreatedByCrafting

### DIFF
--- a/Common/Collectible/Block/BlockBehavior.cs
+++ b/Common/Collectible/Block/BlockBehavior.cs
@@ -169,8 +169,8 @@ namespace Vintagestory.API.Common
         /// <summary>
         /// Everytime the player moves by 8 blocks (or rather leaves the current 8-grid), a scan of all blocks 32x32x32 blocks around the player is initiated
         /// and this method is called. If the method returns true, the block is registered to a client side game ticking for spawning particles and such.
-        /// This method will be called everytime the player left his current 8-grid area. 
-        /// 
+        /// This method will be called everytime the player left his current 8-grid area.
+        ///
         /// The default behavior is to return true if block.ParticleProperties are set
         /// </summary>
         /// <param name="world"></param>
@@ -189,12 +189,12 @@ namespace Vintagestory.API.Common
         public virtual void OnAsyncClientParticleTick(IAsyncParticleManager manager, BlockPos pos, float windAffectednessAtPos, float secondsTicking)
         {
 
-        }   
+        }
 
         /// <summary>
         /// Always called when a block has been removed through whatever method, except during worldgen or via ExchangeBlock()
         /// For Worldgen you might be able to use TryPlaceBlockForWorldGen() to attach custom behaviors during placement/removal
-        /// 
+        ///
         /// The default behavior is to delete the block entity, if this block has any
         /// </summary>
         /// <param name="world"></param>
@@ -237,7 +237,7 @@ namespace Vintagestory.API.Common
             return "";
         }
 
-        
+
 
         public virtual void OnBlockExploded(IWorldAccessor world, BlockPos pos, BlockPos explosionCenter, EnumBlastType blastType, ref EnumHandling handling)
         {
@@ -329,7 +329,7 @@ namespace Vintagestory.API.Common
             handling = EnumHandling.PassThrough;
         }
 
-        public virtual void OnCreatedByCrafting(ItemSlot[] allInputslots, ItemSlot outputSlot, GridRecipe byRecipe, ref EnumHandling handled)
+        public override void OnCreatedByCrafting(ItemSlot[] allInputslots, ItemSlot outputSlot, GridRecipe byRecipe, ref EnumHandling handled)
         {
             handled = EnumHandling.PassThrough;
         }
@@ -354,7 +354,7 @@ namespace Vintagestory.API.Common
 
         public virtual void GetPlacedBlockName(StringBuilder sb, IWorldAccessor world, BlockPos pos)
         {
-            
+
         }
 
         [Obsolete("Use GetRetention() instead")]

--- a/Common/Collectible/Collectible.cs
+++ b/Common/Collectible/Collectible.cs
@@ -859,7 +859,7 @@ namespace Vintagestory.API.Common
             EnumHandling bhHandling = EnumHandling.PassThrough;
             WalkBehaviors(
                 (CollectibleBehavior bh, ref EnumHandling hd) => {
-                    bh.OnCreatedByCrafting(allInputslots, outputSlot, ref bhHandling);
+                    bh.OnCreatedByCrafting(allInputslots, outputSlot, byRecipe, ref bhHandling);
                 },
                 () => {
 

--- a/Common/Collectible/CollectibleBehavior.cs
+++ b/Common/Collectible/CollectibleBehavior.cs
@@ -203,7 +203,7 @@ namespace Vintagestory.API.Common
         /// <param name="renderinfo"></param>
         public virtual void OnBeforeRender(ICoreClientAPI capi, ItemStack itemstack, EnumItemRenderTarget target, ref ItemRenderInfo renderinfo)
         {
-            
+
         }
 
 
@@ -250,7 +250,7 @@ namespace Vintagestory.API.Common
 
         public virtual void GetHeldItemName(StringBuilder sb, ItemStack itemStack)
         {
-            
+
         }
 
         /// <summary>
@@ -306,9 +306,15 @@ namespace Vintagestory.API.Common
             return null;
         }
 
+        [Obsolete("Use OnCreatedByCrafting(ItemSlot[] allInputslots, ItemSlot outputSlot, GridRecipe byRecipe, ref EnumHandling bhHandling) instead")]
         public virtual void OnCreatedByCrafting(ItemSlot[] allInputslots, ItemSlot outputSlot, ref EnumHandling bhHandling)
         {
-            
+        }
+
+        public virtual void OnCreatedByCrafting(ItemSlot[] allInputslots, ItemSlot outputSlot, GridRecipe byRecipe, ref EnumHandling bhHandling)
+        {
+            // Keep this to avoid breaking existing mods that override this method
+            OnCreatedByCrafting(allInputslots, outputSlot, ref bhHandling);
         }
 
         /// <summary>
@@ -371,7 +377,7 @@ namespace Vintagestory.API.Common
 
         public virtual void OnHandbookRecipeRender(ICoreClientAPI capi, GridRecipe recipe, ItemSlot slot, double x, double y, double z, double size)
         {
-            
+
         }
     }
 }


### PR DESCRIPTION
This PR uses the provided `GridRecipe` in `CollectibleBehavior.OnCreatedByCrafting`, allowing collectible behaviors to have access to the used recipe. This is to provide uniformity with other methods with the same name, which all use the grid recipe (`CollectibleObject`, `Block`, `BlockBehavior`).

Idea: The Insanity God (@theinsanitygod on vs discord)