### PR TITLE
Make max dirty attribute path number configurable

### DIFF
--- a/Config/GlobalConstants.cs
+++ b/Config/GlobalConstants.cs
@@ -100,7 +100,7 @@ namespace Vintagestory.API.Config
         /// </summary>
         public static double SprintSpeedMultiplier = 2.0;
 
-        
+
         /// <summary>
         /// Multiplier applied to entity motion while on the ground or in air
         /// </summary>
@@ -120,7 +120,7 @@ namespace Vintagestory.API.Config
         /// Amount of gravity per tick applied to all entities affected by gravity
         /// </summary>
         public static float GravityPerSecond = 0.37f;
-        
+
         /// <summary>
         /// Range in blocks at where this entity is simulated on the server (MagicNum.cs sets this value)
         /// </summary>
@@ -156,6 +156,11 @@ namespace Vintagestory.API.Config
         /// Set by the weather simulation system to determine if snowed variants of blocks should melt. Used a static var to improve performance and reduce memory usage
         /// </summary>
         public static bool MeltingFreezingEnabled;
+
+        /// <summary>
+        /// Max number of dirty attribute paths before the server forces a full tree resync (MagicNum.cs should set this value)
+        /// </summary>
+        public static int MaxDirtyAttributePaths = 20;
 
         public static float GuiGearRotJitter = 0f;
 

--- a/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs
+++ b/Datastructures/AttributeTree/Other/SyncedTreeAttribute.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using Vintagestory.API.Config;
 using Vintagestory.API.Util;
 
 #nullable disable
@@ -20,7 +21,7 @@ namespace Vintagestory.API.Datastructures
         /// Whole tree will be resent
         /// </summary>
         bool allDirty;
-        
+
         /// <summary>
         /// Subtrees will be resent
         /// </summary>
@@ -93,7 +94,7 @@ namespace Vintagestory.API.Datastructures
 
             if (allDirty) return;
 
-            if (attributePathsDirty.Count >= 10)
+            if (attributePathsDirty.Count >= GlobalConstants.MaxDirtyAttributePaths)
             {
                 attributePathsDirty.Clear();
                 allDirty = true;
@@ -242,7 +243,7 @@ namespace Vintagestory.API.Datastructures
         public void PartialUpdate(string path, byte[] data)
         {
             IAttribute attr = GetAttributeByPath(path);
-            
+
             if (data == null)
             {
                 DeleteAttributeByPath(path);


### PR DESCRIPTION
Moves max dirty attribute paths number to GlobalConstants, (which I would like to ask the VS team to extend MagicNum.cs to include this value and propagate it to GlobalConstants.cs, such that this value can be configured from servermagicnumbers.json)

This should allow server owners to dramatically reduce attribute resync bugs that occur when running with large numbers of mods or complex mods at the expense of performance. The important thing being the option to configure it. 

I've also set the default to 20 which is 2x the current max of 10 attribute paths before a full resync, this should help with those running a few basic mods or for potential expansion of attributes being synced as vanilla grows.