### PR TITLE
Make MeshData normalize normal vector before packing to stop bit bleeding

### DIFF
--- a/Client/Model/Mesh/MeshData.cs
+++ b/Client/Model/Mesh/MeshData.cs
@@ -628,7 +628,8 @@ namespace Vintagestory.API.Client
                     double oy = matrix[4 * 0 + 1] * inVec[0] + matrix[4 * 1 + 1] * inVec[1] + matrix[4 * 2 + 1] * inVec[2];
                     double oz = matrix[4 * 0 + 2] * inVec[0] + matrix[4 * 1 + 2] * inVec[1] + matrix[4 * 2 + 2] * inVec[2];
 
-                    Flags[i] = (Flags[i] & ~VertexFlags.NormalBitMask) | (VertexFlags.PackNormal(ox, oy, oz));
+                    double len = Math.Sqrt(ox * ox + oy * oy + oz * oz);
+                    Flags[i] = (Flags[i] & ~VertexFlags.NormalBitMask) | (VertexFlags.PackNormal(ox / len, oy / len, oz / len));
                 }
             }
 


### PR DESCRIPTION
MeshData does not normalize normal vectors during shape tesselation. When shape transform has scaling, (1) the normal vector values bleed into vertex flag wind bits causing faces to incorrectly wave, (2) shading becomes incorrect since normal vertex flags are in wrong bits. This fixes these.

This normalization does not check for divide by zero because the other functions in this file that do vector normalization are also not checking for divide by zero.