### PR TITLE
Add CanEat to support conditional edibility

### DIFF
--- a/Common/Collectible/Collectible.cs
+++ b/Common/Collectible/Collectible.cs
@@ -1757,13 +1757,21 @@ namespace Vintagestory.API.Common
             return true;
         }
 
+        /// <summary>
+        /// Let items with nutrition decide if they're actually edible. Prevents oddities like showing an eating animation that does nothing.
+        /// For example, pies cannot be eaten unless they're both sliced and not raw even though they have nutrition properties.
+        /// </summary>
+        public virtual bool CanEat(ItemSlot slot, EntityAgent byEntity)
+        {
+            return !slot.Empty && GetNutritionProperties(byEntity?.World, slot.Itemstack, byEntity) != null;
+        }
 
         /// <summary>
         /// Tries to eat the contents in the slot, first call
         /// </summary>
         protected virtual void tryEatBegin(ItemSlot slot, EntityAgent byEntity, ref EnumHandHandling handling, string eatSound = "eat", int eatSoundRepeats = 1)
         {
-            if (!slot.Empty && GetNutritionProperties(byEntity.World, slot.Itemstack, byEntity) != null)
+            if (CanEat(slot, byEntity))
             {
                 byEntity.World.RegisterCallback((dt) => playEatSound(byEntity, eatSound, eatSoundRepeats), 500);
 
@@ -1799,7 +1807,7 @@ namespace Vintagestory.API.Common
         /// <param name="spawnParticleStack"></param>
         protected virtual bool tryEatStep(float secondsUsed, ItemSlot slot, EntityAgent byEntity, ItemStack spawnParticleStack = null)
         {
-            if (GetNutritionProperties(byEntity.World, slot.Itemstack, byEntity) == null) return false;
+            if (!CanEat(slot, byEntity)) return false;
 
             Vec3d pos = byEntity.Pos.AheadCopy(0.4f).XYZ;
             pos.X += byEntity.LocalEyePos.X;
@@ -1830,7 +1838,7 @@ namespace Vintagestory.API.Common
         {
             FoodNutritionProperties nutriProps = GetNutritionProperties(byEntity.World, slot.Itemstack, byEntity);
 
-            if (byEntity.World is IServerWorldAccessor && nutriProps != null && secondsUsed >= 0.95f)
+            if (byEntity.World is IServerWorldAccessor && nutriProps != null && CanEat(slot, byEntity) && secondsUsed >= 0.95f)
             {
                 TransitionState state = UpdateAndGetTransitionState(api.World, slot, EnumTransitionType.Perish);
                 float spoilState = state != null ? state.TransitionLevel : 0;
@@ -2143,7 +2151,7 @@ namespace Vintagestory.API.Common
         {
             WorldInteraction[] interactions;
 
-            if (GetNutritionProperties(api.World, inSlot.Itemstack, null) != null)
+            if (CanEat(inSlot, null))
             {
                 interactions = new WorldInteraction[]
                 {


### PR DESCRIPTION
Some foods have edibility requirements for which nutritionPropsByType is not a suitable solution. For example, pies store their size as an attribute and must manually check a unique edibility method in otherwise empty held interaction method overrides.

This is a simple and flexible way to provide users the ability to restrict the edibility of their custom foods based on any combination of properties and attributes, such as item code, transition state, or temperature. In addition to preventing actual eating, other code can use this to determine other behaviors, such as whether or not to play an eating animation.