### PR TITLE
Update GetHeldItemInfo for firepit properties

### DIFF
--- a/Common/Collectible/Collectible.cs
+++ b/Common/Collectible/Collectible.cs
@@ -2103,8 +2103,8 @@ namespace Vintagestory.API.Common
                 {
                     if (combustibleProps.BurnTemperature > 0)
                     {
-                        dsc.AppendLine(Lang.Get("Burn temperature: {0}°C", combustibleProps.BurnTemperature));
-                        dsc.AppendLine(Lang.Get("Burn duration: {0}s", combustibleProps.BurnDuration));
+                        dsc.AppendLine(Lang.Get("Firepit burn temperature: {0}°C", combustibleProps.BurnTemperature));
+                        dsc.AppendLine(Lang.Get("Firepit burn duration: {0}s", combustibleProps.BurnDuration));
                     }
 
                     if (combustibleProps.MeltingPoint > 0)


### PR DESCRIPTION
Explicitly specify that standard combustible properties refer to _firepit_ burn temperature and duration. This is a counterpart to [this change to forge burning properties tooltips](https://github.com/anegostudios/vssurvivalmod/pull/195). The two in combination make coal item tooltips clearer and more useful.