### PR TITLE
Null SideProperties Error in GetBehavior

### DIFF
--- a/Common/Entity/Entity.cs
+++ b/Common/Entity/Entity.cs
@@ -1758,7 +1758,7 @@ namespace Vintagestory.API.Common.Entities
         /// <returns></returns>
         public virtual EntityBehavior? GetBehavior(string name)
         {
-            List<EntityBehavior>? behaviors = SidedProperties.Behaviors;
+            List<EntityBehavior>? behaviors = SidedProperties?.Behaviors;
 
             if (behaviors == null)
             {
@@ -1782,7 +1782,7 @@ namespace Vintagestory.API.Common.Entities
         /// <returns></returns>
         public virtual TEntityBehavior? GetBehavior<TEntityBehavior>() where TEntityBehavior : EntityBehavior
         {
-            List<EntityBehavior>? behaviors = SidedProperties.Behaviors;
+            List<EntityBehavior>? behaviors = SidedProperties?.Behaviors;
 
             if (behaviors == null)
             {


### PR DESCRIPTION
It is possible that SidedProperties can be null but GetBehavior is called. This can result in the error message Exception: Object reference not set to an instance of an object. Adding a null-conditional operator to SidedProperties will allow protecting against this rare error.