### PR TITLE
Optimize ColumnNoise with Thread-Local Storage

### DIFF
--- a/Math/Noise/NewNormalizedSimplexFractalNoise.cs
+++ b/Math/Noise/NewNormalizedSimplexFractalNoise.cs
@@ -126,8 +126,19 @@ namespace Vintagestory.API.MathTools
 
         public struct ColumnNoise
         {
-            OctaveEntry[] orderedOctaveEntries;
-            PastEvaluation[] pastEvaluations;
+            // Thread-isolated static arrays (TLS).
+            // Size 48 covers any possible world height.
+            [ThreadStatic] private static OctaveEntry[] _threadOctaves;
+            [ThreadStatic] private static PastEvaluation[] _threadPastEvals;
+            [ThreadStatic] private static double[] _threadMaxValues;
+            [ThreadStatic] private static int[] _threadOrder;
+
+            // References to TLS arrays for quick access within methods
+            private OctaveEntry[] orderedOctaveEntries;
+            private PastEvaluation[] pastEvaluations;
+
+            // Strict limitation for loops since arrays can be longer
+            private int nUsedOctaves;
 
             public double UncurvedBound { get; private set; }
             public double BoundMin { get; private set; }
@@ -147,9 +158,22 @@ namespace Vintagestory.API.MathTools
             public ColumnNoise(NewNormalizedSimplexFractalNoise terrainNoise, double relativeYFrequency, double[] amplitudes, double[] thresholds, double noiseX, double noiseZ)
             {
                 int nAvailableOctaves = terrainNoise.frequencies.Length;
-                int nUsedOctaves = 0;
-                double[] maxValues = new double[nAvailableOctaves];
-                int[] order = new int[nAvailableOctaves];
+
+                // Initialize or expand TLS arrays on first call in a thread
+                if (_threadOctaves == null || _threadOctaves.Length < nAvailableOctaves)
+                {
+                    int newSize = Math.Max(48, nAvailableOctaves);
+                    _threadOctaves = new OctaveEntry[newSize];
+                    _threadPastEvals = new PastEvaluation[newSize];
+                    _threadMaxValues = new double[newSize];
+                    _threadOrder = new int[newSize];
+                }
+
+                // Binding local links to TLS arrays
+                double[] maxValues = _threadMaxValues;
+                int[] order = _threadOrder;
+
+                int nUsedOctavesLocal = 0;
                 double bound = 0;
                 for (int i = nAvailableOctaves - 1; i >= 0; i--)
                 {
@@ -161,8 +185,8 @@ namespace Vintagestory.API.MathTools
                     if (maxValues[i] == 0) continue;
 
                     // Descending order: Biggest octaves first, so we can rule out layers sooner.
-                    order[nUsedOctaves] = i;
-                    for (int j = nUsedOctaves - 1; j >= 0; j--)
+                    order[nUsedOctavesLocal] = i;
+                    for (int j = nUsedOctavesLocal - 1; j >= 0; j--)
                     {
                         if (maxValues[order[j + 1]] > maxValues[order[j]])
                         {
@@ -171,17 +195,20 @@ namespace Vintagestory.API.MathTools
                             order[j + 1] = temp;
                         }
                     }
-                    nUsedOctaves++;
+                    nUsedOctavesLocal++;
                 }
+
                 this.UncurvedBound = bound;
                 this.BoundMin = NoiseValueCurve(-bound);
                 this.BoundMax = NoiseValueCurve(bound);
+                this.nUsedOctaves = nUsedOctavesLocal;
 
-                // Fill out noise generators in order
-                this.orderedOctaveEntries = new OctaveEntry[nUsedOctaves];
-                this.pastEvaluations = new PastEvaluation[nUsedOctaves];
+                // reuse _threadOctaves and _threadPastEvals
+                this.orderedOctaveEntries = _threadOctaves;
+                this.pastEvaluations = _threadPastEvals;
+
                 double uncertaintySum = 0;
-                for (int j = nUsedOctaves - 1; j >= 0; j--)
+                for (int j = nUsedOctavesLocal - 1; j >= 0; j--)
                 {
                     int i = order[j];
                     uncertaintySum += maxValues[i];
@@ -212,7 +239,9 @@ namespace Vintagestory.API.MathTools
                 const double maxYSlope = NewSimplexNoiseLayer.MaxYSlope_ImprovedXZ;
                 double valueTempMin = inverseCurvedThresholder;
                 double valueTempMax = inverseCurvedThresholder;
-                for (int j = 0; j < orderedOctaveEntries.Length; j++)
+
+                // Iterate strictly up to nUsedOctaves
+                for (int j = 0; j < nUsedOctaves; j++)
                 {
                     // Exit if we couldn't possibly trigger an early return within this loop.
                     if (!(valueTempMax <= 0) && !(valueTempMin >= 0)) break;
@@ -227,10 +256,10 @@ namespace Vintagestory.API.MathTools
                     double evalY = y * octaveEntry.FrequencyY;
                     double deltaY = Math.Abs(pastEvaluations[j].Y - evalY);
                     valueTempMin += ApplyThresholding(Math.Max(-1, pastEvaluations[j].Value - deltaY * maxYSlope) * octaveEntry.Amplitude, octaveEntry.Threshold, octaveEntry.SmoothingFactor);
-                    valueTempMax += ApplyThresholding(Math.Min( 1, pastEvaluations[j].Value + deltaY * maxYSlope) * octaveEntry.Amplitude, octaveEntry.Threshold, octaveEntry.SmoothingFactor);
+                    valueTempMax += ApplyThresholding(Math.Min(1, pastEvaluations[j].Value + deltaY * maxYSlope) * octaveEntry.Amplitude, octaveEntry.Threshold, octaveEntry.SmoothingFactor);
                 }
 
-                for (int j = 0; j < orderedOctaveEntries.Length; j++)
+                for (int j = 0; j < nUsedOctaves; j++)
                 {
                     ref readonly OctaveEntry octaveEntry = ref orderedOctaveEntries[j];
 
@@ -252,7 +281,9 @@ namespace Vintagestory.API.MathTools
             public double Noise(double y)
             {
                 double value = 0.0;
-                for (int j = 0; j < orderedOctaveEntries.Length; j++)
+
+                // Iterate strictly up to nUsedOctaves
+                for (int j = 0; j < nUsedOctaves; j++)
                 {
                     ref readonly OctaveEntry octaveEntry = ref orderedOctaveEntries[j];
 
@@ -262,6 +293,8 @@ namespace Vintagestory.API.MathTools
                 }
                 return NoiseValueCurve(value);
             }
+
+
         }
     }
 }


### PR DESCRIPTION
## Summary

Here are the main code changes that have virtually eliminated GC garbage generation:

- **Replacing local allocations with a thread-static cache.** Instead of creating new arrays (OctaveEntry[], PastEvaluation[], double[] maxValues, int[] order) in the constructor of each ColumnNoise, static fields with the [ThreadStatic] attribute are now used. Arrays are allocated once per thread and reused for all subsequent calls.

- **Lazy initialization and cache expansion.** When first accessed from a thread, arrays are created with a size of Max(48, number of octaves). If more octaves are needed in the future, the arrays are automatically expanded. This covers all real-world configurations without unnecessary allocations.

- **Fixing the actual number of used octaves (nUsedOctaves).** The nUsedOctaves field has been added, storing the exact number of active octaves. All loops (NoiseSign, Noise) now iterate up to this limit, rather than up to the array length. This allows for safe use of larger reusable arrays.

- **Resetting state via overwriting.** Data from previous evaluations (pastEvaluations) is overwritten in place. Unused elements are simply not read due to the loop limit of nUsedOctaves.


## Performance numbers

Testing on 10,200 generation column chunks:
- GC load: decreased from 10.22 Gb to 250 MB

Comparisons of execution times are impossible because these modifications are performed in parallel threads, which the OS may manage differently each time. The only noticeable difference is the GC runtime.

**Before**
<img width="1597" height="473" alt="newnormalize before mem" src="https://github.com/user-attachments/assets/fe5368dd-3642-42c5-8b97-ae2f13a46364" />
<img width="724" height="592" alt="newnormalize before trace" src="https://github.com/user-attachments/assets/d007c6b1-f15a-4ed0-8c13-5f33f1100763" />
<img width="1920" height="1017" alt="2026-07-01_08-50-51" src="https://github.com/user-attachments/assets/0b5dd54d-93ac-42cf-9fdc-9fcca9e36d98" />
<img width="1920" height="1017" alt="2026-07-01_08-49-37" src="https://github.com/user-attachments/assets/f54e076d-4165-4678-8796-eb552e856156" />
<img width="1920" height="1017" alt="2026-07-01_08-48-18" src="https://github.com/user-attachments/assets/a8151783-66b4-4e51-840f-08668cdbda54" />


**After**
<img width="1583" height="512" alt="newnormalize after mem" src="https://github.com/user-attachments/assets/6edcb69f-9c74-41e8-af98-34c56d210b88" />
<img width="734" height="647" alt="newnormalize after trace" src="https://github.com/user-attachments/assets/c96c33be-3eb2-4f46-a01d-e11abe7b42b9" />
<img width="1920" height="1017" alt="2026-07-01_08-38-00" src="https://github.com/user-attachments/assets/5d0bc764-4604-4cfe-85ae-0218d9a7382a" />
<img width="1920" height="1017" alt="2026-07-01_08-38-49" src="https://github.com/user-attachments/assets/d8016f62-6968-476a-84d9-050811eeb566" />
<img width="1920" height="1017" alt="2026-07-01_08-39-32" src="https://github.com/user-attachments/assets/a8ecbd5e-cc0c-4ad3-8faf-d7d3ab2f9a0f" />
