### PR TITLE
Fix: Looping sounds not registered correctly

### DIFF
--- a/Common/Model/Animation/AnimationManager.cs
+++ b/Common/Model/Animation/AnimationManager.cs
@@ -480,17 +480,14 @@ namespace Vintagestory.API.Common
                 runTriggers();
             }
 
-            if (loopingSounds != null)
+            foreach (var val in loopingSounds)
             {
-                foreach (var val in loopingSounds)
+                if (!ActiveAnimationsByAnimCode.ContainsKey(val.Key))
                 {
-                    if (!ActiveAnimationsByAnimCode.ContainsKey(val.Key))
-                    {
-                        val.Value.Stop();
-                        val.Value.Dispose();
-                        loopingSounds.Remove(val.Key);
-                        break;
-                    }
+                    val.Value.Stop();
+                    val.Value.Dispose();
+                    loopingSounds.Remove(val.Key);
+                    break;
                 }
             }
         }
@@ -527,13 +524,10 @@ namespace Vintagestory.API.Common
         /// </summary>
         public void Dispose()
         {
-            if (loopingSounds != null)
+            foreach (var val in loopingSounds)
             {
-                foreach (var val in loopingSounds)
-                {
-                    val.Value.Stop();
-                    val.Value.Dispose();
-                }
+                val.Value.Stop();
+                val.Value.Dispose();
             }
         }
 
@@ -558,8 +552,6 @@ namespace Vintagestory.API.Common
                 var cworld = world as IClientWorldAccessor;
                 if (cworld != null)
                 {
-                    if (loopingSounds == null) loopingSounds = new Dictionary<string, ILoadedSound>();
-
                     ILoadedSound lsound;
                     if (!loopingSounds.TryGetValue(animationMetaCode, out lsound))
                     {

--- a/Common/Model/Animation/AnimationManager.cs
+++ b/Common/Model/Animation/AnimationManager.cs
@@ -542,7 +542,7 @@ namespace Vintagestory.API.Common
             OnAnimationStopped?.Invoke(code);
         }
 
-        Dictionary<string, ILoadedSound> loopingSounds = null;
+        Dictionary<string, ILoadedSound> loopingSounds = [];
 
         public void ShouldPlaySound(string animationMetaCode, AnimationSound sound)
         {


### PR DESCRIPTION
Fixes [#9809](https://github.com/anegostudios/VintageStory-Issues/issues/9809):
- Issue: Uninitialized `loopingSounds` passed as an argument to `ShouldPlaySound()` is only initialized locally.
- Fix: Add a field initializer.
- Example alternative: Pass `loopingSounds` by reference, so that lazy initialization in `ShouldPlaySound()` works outside of the method's scope.