### PR TITLE
Optimization of FirstCodePart and LastCodePart

### DIFF
--- a/Common/Registry/RegistryObject.cs
+++ b/Common/Registry/RegistryObject.cs
@@ -212,11 +212,40 @@ namespace Vintagestory.API.Common
         /// <returns></returns>
         public string LastCodePart(int posFromRight = 0)
         {
-            if (Code == null) return null;
-            if (posFromRight == 0 && !Code.Path.Contains('-')) return Code.Path;
+            if (Code == null)
+                return null;
 
-            string[] parts = Code.Path.Split('-');
-            return parts.Length - 1 - posFromRight >= 0 ? parts[parts.Length - 1 - posFromRight] : null;
+            string path = Code.Path;
+            int rightBoundary = path.Length;    // Right boundary of the current found part (initially end of string)
+            int dashesSeen = -1;    // Number of dashes encountered while traversing right to left
+            int i = path.Length;    // i — current index while traversing right to left
+
+            // Traverse the string right to left searching for dashes
+            while (--i >= 0)
+            {
+                if (path[i] != '-')
+                    continue;
+
+                dashesSeen++;
+
+                // If we found the needed dash (index posFromRight), return the part between it and rightBoundary
+                if (dashesSeen == posFromRight)
+                {
+                    return path.Substring(i + 1, rightBoundary - i - 1);
+                }
+                // Otherwise shift the right boundary — now it points to the current dash
+                rightBoundary = i;
+            }
+
+            // Reached the start of the string — not enough dashes
+            // If the last part was requested
+            if (posFromRight == 0)
+                return dashesSeen == -1 ? path : null;
+
+            // If a non-last part was requested, check if there were enough dashes
+            // dashesSeen == posFromRight - 1 means there were exactly enough dashes
+            // to extract the requested part from the start of the string to the first dash
+            return dashesSeen == posFromRight - 1 ? path.Substring(0, rightBoundary) : null;
         }
 
         /// <summary>
@@ -226,11 +255,38 @@ namespace Vintagestory.API.Common
         /// <returns></returns>
         public string FirstCodePart(int posFromLeft = 0)
         {
-            if (Code == null) return null;
-            if (posFromLeft == 0 && !Code.Path.Contains('-')) return Code.Path;
+            if (Code == null)
+                return null;
 
-            string[] parts = Code.Path.Split('-');
-            return posFromLeft <= parts.Length - 1 ? parts[posFromLeft] : null;
+            string path = Code.Path;
+            int leftBoundary = 0;   // Left boundary of the current found part (initially start of string)
+            int dashesSeen = -1;    // Number of dashes encountered while traversing left to right
+
+            // Traverse the string left to right searching for dashes
+            for (int i = 0; i < path.Length; i++)
+            {
+                if (path[i] != '-')
+                    continue;
+
+                dashesSeen++;
+                // If we found the needed dash, return the part between leftBoundary and it
+                if (dashesSeen == posFromLeft)
+                {
+                    return path.Substring(leftBoundary, i - leftBoundary);
+                }
+                // Otherwise shift the left boundary — now it points to the position after the current dash
+                leftBoundary = i + 1;
+            }
+
+            // Reached the end of the string — not enough dashes
+            // If the first part was requested
+            if (posFromLeft == 0)
+                return dashesSeen == -1 ? path : null;
+
+            // If a non-first part was requested, check if there were enough dashes
+            // dashesSeen == posFromLeft - 1 means there were exactly enough dashes
+            // to extract the requested part from the last dash to the end of the string
+            return dashesSeen == posFromLeft - 1 ? path.Substring(leftBoundary) : null;            
         }
 
         /// <summary>


### PR DESCRIPTION
## Summary

Replacing the resource-intensive **Split()** with a character-by-character iteration with early exit allowed the string to be read exactly once, stopping at the required hyphen without creating intermediate arrays.
This dramatically reduced the load on the GC and significantly accelerated the method's execution in hot sections of code by completely eliminating unnecessary memory allocations.

[Also sent to Stratum](https://github.com/StratumServer/Stratum/pull/119)

## Performance numbers

Tested on the generation of 10200 chunk columns:
- GenVegetationAndPatches.genPatches method execution time: reduced from 6564 ms to 6015 ms;
- GenVegetationAndPatches.genPatches GC memory allocations: reduced from 1.24 GB to 827 MB.

**Before**
<img width="776" height="737" alt="registry before trace" src="https://github.com/user-attachments/assets/8ba6029f-a12b-4ac4-ac3c-60994106a0e5" />
<img width="1616" height="449" alt="registry before mem" src="https://github.com/user-attachments/assets/3141e576-466c-4939-bad3-15413af43d9c" />


**After**
<img width="769" height="714" alt="registry after trace" src="https://github.com/user-attachments/assets/f5151ca8-a099-4430-b89b-c6e168c6cffa" />
<img width="1676" height="460" alt="registry after mem" src="https://github.com/user-attachments/assets/a9d8a846-69c6-4b0b-96f5-cd0cfe42cd38" />
