### PR TITLE
Refactor Equals method for EvolvingNatFloat

### DIFF
--- a/Math/EvolvingNatFloat.cs
+++ b/Math/EvolvingNatFloat.cs
@@ -156,10 +156,16 @@ namespace Vintagestory.API.MathTools
             return evo;
         }
 
-        public override bool Equals([NotNullWhen(true)] object obj)
+        // Add a typed overload 
+        // This way we avoid constant conversions of EvolvingNatFloat to object
+        public bool Equals(EvolvingNatFloat other)
         {
-            if (obj is not EvolvingNatFloat enf) return false;
-            return enf.Transform == Transform && enf.factor == factor;
+            return other.Transform == Transform && other.factor == factor;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is EvolvingNatFloat other && Equals(other);
         }
 
         public static bool operator ==(EvolvingNatFloat left, EvolvingNatFloat right)


### PR DESCRIPTION
An overload has also been added to **EvolvingNatFloat**, which allows you to compare these objects without converting to object.

Included in statistics in this [PR](https://github.com/anegostudios/vsessentialsmod/pull/50)